### PR TITLE
fallback to k8s mechanisms, fix #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Manage and monitor EDA (Event Driven Automation by Nokai) resources in Kubernetes",
   "author": "EDA Labs",
   "homepage": "https://docs.eda.dev/",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "vscode": "^1.70.0"
   },


### PR DESCRIPTION
If the ressource can't be feteched by edactl, we will fallback to kubectl. This closes #2 