### PR TITLE
Fix labels display formatting in grid labels column

### DIFF
--- a/src/webviews/shared/components/DataGridDashboard.tsx
+++ b/src/webviews/shared/components/DataGridDashboard.tsx
@@ -7,6 +7,7 @@ import type { GridAutosizeOptions, GridColDef, GridSortModel } from '@mui/x-data
 import { shallowArrayEquals } from '../utils';
 import { usePostMessage, useMessageListener, useReadySignal } from '../hooks';
 
+import { parseLabelsText, toLabelText, type ParsedLabel } from './labelUtils';
 import { VSCodeButton } from './VsCodeButton';
 import { VsCodeDataGrid } from './VsCodeDataGrid';
 
@@ -77,11 +78,6 @@ export interface DataGridToolbarContext extends DataGridContext {
 interface DashboardRow {
   id: string;
   raw: unknown[];
-}
-
-interface ParsedLabel {
-  key: string;
-  value: string;
 }
 
 interface LabelsCellProps {
@@ -304,30 +300,8 @@ function formatGridCellValue(value: unknown): string {
   return String(value);
 }
 
-function parseLabelLine(line: string): ParsedLabel {
-  const separatorIndex = line.indexOf('=');
-  if (separatorIndex < 0) {
-    return {
-      key: 'label',
-      value: line
-    };
-  }
-  return {
-    key: line.slice(0, separatorIndex).trim() || 'label',
-    value: line.slice(separatorIndex + 1).trim()
-  };
-}
-
-function parseLabels(value: string): ParsedLabel[] {
-  const lines = value
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  return lines.map((line) => parseLabelLine(line));
-}
-
 function estimateLabelWidth(label: ParsedLabel): number {
-  const textLength = `${label.key}${label.value}`.length;
+  const textLength = toLabelText(label).length;
   const estimatedTextWidth = Math.min(textLength, 64) * 7;
   return Math.max(72, estimatedTextWidth + 28);
 }
@@ -336,7 +310,7 @@ function LabelChip({ label, expanded, setMeasureRef }: Readonly<LabelChipProps>)
   return (
     <Box
       ref={setMeasureRef}
-      title={`${label.key}=${label.value}`}
+      title={toLabelText(label)}
       sx={{
         display: 'inline-flex',
         alignItems: 'baseline',
@@ -353,13 +327,6 @@ function LabelChip({ label, expanded, setMeasureRef }: Readonly<LabelChipProps>)
       }}
     >
       <Typography
-        variant="caption"
-        component="span"
-        sx={{ fontFamily: 'monospace', color: 'text.secondary', lineHeight: 1.2, whiteSpace: 'nowrap' }}
-      >
-        {label.key}
-      </Typography>
-      <Typography
         variant="body2"
         component="span"
         sx={{
@@ -371,14 +338,14 @@ function LabelChip({ label, expanded, setMeasureRef }: Readonly<LabelChipProps>)
           wordBreak: expanded ? 'break-word' : 'normal'
         }}
       >
-        {label.value}
+        {toLabelText(label)}
       </Typography>
     </Box>
   );
 }
 
 function LabelsCell({ value, rowId }: Readonly<LabelsCellProps>): ReactNode {
-  const labels = useMemo(() => parseLabels(value), [value]);
+  const labels = useMemo(() => parseLabelsText(value), [value]);
   const [expanded, setExpanded] = useState(false);
   const [cellWidth, setCellWidth] = useState(0);
   const [visibleCount, setVisibleCount] = useState(labels.length);

--- a/src/webviews/shared/components/labelUtils.ts
+++ b/src/webviews/shared/components/labelUtils.ts
@@ -1,0 +1,55 @@
+export type LabelSeparator = '=' | ':';
+
+export interface ParsedLabel {
+  key: string;
+  value: string;
+  separator: LabelSeparator;
+}
+
+const DEFAULT_LABEL_KEY = 'label';
+const DEFAULT_LABEL_SEPARATOR: LabelSeparator = '=';
+
+function resolveSeparator(line: string): { index: number; separator: LabelSeparator } | undefined {
+  const equalsIndex = line.indexOf('=');
+  const colonIndex = line.indexOf(':');
+  if (equalsIndex < 0 && colonIndex < 0) {
+    return undefined;
+  }
+  if (equalsIndex < 0) {
+    return { index: colonIndex, separator: ':' };
+  }
+  if (colonIndex < 0) {
+    return { index: equalsIndex, separator: '=' };
+  }
+  return equalsIndex < colonIndex
+    ? { index: equalsIndex, separator: '=' }
+    : { index: colonIndex, separator: ':' };
+}
+
+export function parseLabelLine(line: string): ParsedLabel {
+  const resolved = resolveSeparator(line);
+  if (!resolved) {
+    return {
+      key: DEFAULT_LABEL_KEY,
+      value: line.trim(),
+      separator: DEFAULT_LABEL_SEPARATOR
+    };
+  }
+  return {
+    key: line.slice(0, resolved.index).trim() || DEFAULT_LABEL_KEY,
+    value: line.slice(resolved.index + 1).trim(),
+    separator: resolved.separator
+  };
+}
+
+export function parseLabelsText(value: string): ParsedLabel[] {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return lines.map((line) => parseLabelLine(line));
+}
+
+export function toLabelText(label: Readonly<ParsedLabel>): string {
+  return `${label.key}${label.separator}${label.value}`;
+}

--- a/test/labelUtils.test.ts
+++ b/test/labelUtils.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import { parseLabelLine, parseLabelsText, toLabelText } from '../src/webviews/shared/components/labelUtils';
+
+describe('labelUtils', () => {
+  it('parses equals-separated labels', () => {
+    const label = parseLabelLine('eda.nokia.com/role=leaf');
+    expect(label).to.deep.equal({
+      key: 'eda.nokia.com/role',
+      value: 'leaf',
+      separator: '='
+    });
+    expect(toLabelText(label)).to.equal('eda.nokia.com/role=leaf');
+  });
+
+  it('parses colon-separated labels', () => {
+    const label = parseLabelLine('eda.nokia.com/role: leaf');
+    expect(label).to.deep.equal({
+      key: 'eda.nokia.com/role',
+      value: 'leaf',
+      separator: ':'
+    });
+    expect(toLabelText(label)).to.equal('eda.nokia.com/role:leaf');
+  });
+
+  it('falls back to default key when separator is missing', () => {
+    const label = parseLabelLine('orphan-value');
+    expect(label).to.deep.equal({
+      key: 'label',
+      value: 'orphan-value',
+      separator: '='
+    });
+    expect(toLabelText(label)).to.equal('label=orphan-value');
+  });
+
+  it('parses and filters multiline label text', () => {
+    const labels = parseLabelsText('\neda.nokia.com/role=leaf\n\neda.nokia.com/site: west\n');
+    expect(labels).to.deep.equal([
+      { key: 'eda.nokia.com/role', value: 'leaf', separator: '=' },
+      { key: 'eda.nokia.com/site', value: 'west', separator: ':' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- render label chips as a single text token with an explicit separator so key/value style is consistent
- preserve original label separator parsing (= or :) and centralize parsing/formatting in a shared helper
- add focused unit tests for label parsing and rendering text output

## Testing
- npm run check-types
- npx oxlint src/webviews/shared/components/DataGridDashboard.tsx src/webviews/shared/components/labelUtils.ts test/labelUtils.test.ts
- npm test -- test/labelUtils.test.ts

Closes #172
