### PR TITLE
Fix explorer resource list live sync (rows + actions)

### DIFF
--- a/src/commands/explorerResourceListCommand.ts
+++ b/src/commands/explorerResourceListCommand.ts
@@ -1,15 +1,44 @@
 import * as vscode from 'vscode';
 
+import type { TreeItemBase } from '../providers/views/treeItem';
 import type { ExplorerAction } from '../webviews/shared/explorer/types';
 import type {
   ExplorerResourceListItemPayload,
-  ExplorerResourceListPayload
+  ExplorerResourceListPayload,
+  ExplorerResourceListViewKind
 } from '../webviews/explorer/explorerResourceListTypes';
 
 const ALL_RESOURCE_NAMESPACES_VALUE = '__all_namespaces__';
+const CONTEXT_STREAM = 'stream';
+const CONTEXT_RESOURCE_CATEGORY = 'resource-category';
+const CONTEXT_MESSAGE = 'message';
+const CONTEXT_INFO = 'info';
+const CMD_VIEW_STREAM_ITEM = 'vscode-eda.viewStreamItem';
+const CMD_VIEW_RESOURCE = 'vscode-eda.viewResource';
+const CMD_EDIT_RESOURCE = 'vscode-eda.switchToEditResource';
+const CMD_DELETE_RESOURCE = 'vscode-eda.deleteResource';
+const LABEL_EDIT_RESOURCE = 'Switch To Edit Mode';
+const LABEL_DELETE_RESOURCE = 'Delete Resource';
+
+interface ResourceTreeProvider {
+  getChildren(element?: TreeItemBase): vscode.ProviderResult<TreeItemBase[]>;
+  onDidChangeTreeData?: vscode.Event<TreeItemBase | undefined | null | void>;
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function labelToText(value: string | vscode.TreeItemLabel): string {
+  return typeof value === 'string' ? value : value.label;
+}
+
+function isResourceListViewKind(value: unknown): value is ExplorerResourceListViewKind {
+  return value === 'resources'
+    || value === 'alarms'
+    || value === 'deviations'
+    || value === 'basket'
+    || value === 'transactions';
 }
 
 function getNonEmptyString(holder: Record<string, unknown>, key: string): string | undefined {
@@ -102,6 +131,12 @@ function normalizePayload(value: unknown): ExplorerResourceListPayload | undefin
   const namespace = typeof value.namespace === 'string' && value.namespace
     ? value.namespace
     : ALL_RESOURCE_NAMESPACES_VALUE;
+  const viewKind = isResourceListViewKind(value.viewKind) ? value.viewKind : undefined;
+  const sourceNodeId = getNonEmptyString(value, 'sourceNodeId');
+  const sourceNodeContext = value.sourceNodeContext === CONTEXT_STREAM
+    || value.sourceNodeContext === CONTEXT_RESOURCE_CATEGORY
+    ? value.sourceNodeContext
+    : undefined;
 
   const resources = Array.isArray(value.resources)
     ? value.resources
@@ -112,11 +147,442 @@ function normalizePayload(value: unknown): ExplorerResourceListPayload | undefin
   return {
     title,
     namespace,
+    viewKind,
+    sourceNodeId,
+    sourceNodeContext,
     resources
   };
 }
 
-export function registerExplorerResourceListCommand(context: vscode.ExtensionContext): void {
+function descriptionToText(value: string | boolean | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const text = value.trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function normalizeLookupSegment(value: string | undefined): string {
+  return (value || '').trim();
+}
+
+function makeSortKey(namespace: string, name: string): string {
+  return `${namespace.toLowerCase()}\u0000${name.toLowerCase()}`;
+}
+
+function commandToAction(command: vscode.Command | undefined): ExplorerAction | undefined {
+  if (!command?.command) {
+    return undefined;
+  }
+
+  const args = Array.isArray(command.arguments) ? command.arguments : undefined;
+  return {
+    id: `${command.command}:${command.title || 'Open'}`,
+    label: command.title || 'Open',
+    command: command.command,
+    args
+  };
+}
+
+function createAction(command: string, label: string, args?: unknown[]): ExplorerAction {
+  return {
+    id: `${command}:${label}`,
+    label,
+    command,
+    args
+  };
+}
+
+function dedupeActions(actions: ExplorerAction[]): ExplorerAction[] {
+  const seen = new Set<string>();
+  const unique: ExplorerAction[] = [];
+  for (const action of actions) {
+    const key = `${action.command}:${action.label}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(action);
+  }
+  return unique;
+}
+
+function formatLabels(item: TreeItemBase): string | undefined {
+  const labels = item.resource?.raw?.metadata?.labels;
+  if (!labels || typeof labels !== 'object') {
+    return undefined;
+  }
+  const entries = Object.entries(labels)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .sort((left, right) => left[0].localeCompare(right[0]));
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return entries.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+function resolveNamespace(item: TreeItemBase): string {
+  return item.namespace || item.resource?.namespace || '';
+}
+
+function resolveName(item: TreeItemBase): string {
+  const fromResource = item.resource?.name;
+  if (fromResource) {
+    return fromResource;
+  }
+  const label = labelToText(item.label);
+  const slash = label.indexOf('/');
+  if (slash >= 0 && slash < label.length - 1) {
+    return label.slice(slash + 1);
+  }
+  return label;
+}
+
+function resolveStatusDescription(item: TreeItemBase): string | undefined {
+  return item.status?.description || descriptionToText(item.description);
+}
+
+function getNodeDetails(raw: unknown): string | undefined {
+  const status = raw && typeof raw === 'object' && 'status' in raw
+    ? (raw.status as Record<string, unknown> | undefined)
+    : undefined;
+  const value = status?.['node-details'];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function buildResourceCommandArgument(item: TreeItemBase): Record<string, unknown> {
+  const label = labelToText(item.label);
+  const name = resolveName(item);
+  const namespace = resolveNamespace(item);
+  const kind = item.resource?.kind ?? item.resourceType ?? 'Resource';
+  const apiVersion = item.resource?.apiVersion;
+  const raw = item.resource?.raw;
+
+  const arg: Record<string, unknown> = {
+    label,
+    namespace,
+    resourceType: item.resourceType,
+    streamGroup: item.streamGroup,
+    contextValue: item.contextValue,
+    name,
+    kind,
+    apiVersion
+  };
+
+  const labelsText = formatLabels(item);
+  if (labelsText) {
+    arg.labelsText = labelsText;
+  }
+
+  const nodeDetails = getNodeDetails(raw);
+  if (nodeDetails) {
+    arg.nodeDetails = nodeDetails;
+  }
+
+  arg.resource = {
+    name,
+    namespace,
+    kind,
+    apiVersion,
+    uid: item.resource?.uid
+  };
+
+  return arg;
+}
+
+function buildResourceActions(contextValue: string | undefined, commandArg: Record<string, unknown>): ExplorerAction[] {
+  if (!contextValue) {
+    return [];
+  }
+
+  const common = [
+    createAction(CMD_VIEW_STREAM_ITEM, 'View Stream Item', [commandArg]),
+    createAction(CMD_VIEW_RESOURCE, 'View Resource YAML', [commandArg])
+  ];
+
+  if (contextValue === 'pod') {
+    return [
+      ...common,
+      createAction('vscode-eda.logsPod', 'View Logs', [commandArg]),
+      createAction('vscode-eda.describePod', 'Describe Pod', [commandArg]),
+      createAction('vscode-eda.terminalPod', 'Open Terminal', [commandArg]),
+      createAction('vscode-eda.deletePod', 'Delete Pod', [commandArg])
+    ];
+  }
+
+  if (contextValue === 'k8s-deployment-instance') {
+    return [
+      ...common,
+      createAction('vscode-eda.restartDeployment', 'Restart Deployment', [commandArg]),
+      createAction(CMD_EDIT_RESOURCE, LABEL_EDIT_RESOURCE, [commandArg]),
+      createAction(CMD_DELETE_RESOURCE, LABEL_DELETE_RESOURCE, [commandArg])
+    ];
+  }
+
+  if (contextValue === 'toponode') {
+    return [
+      ...common,
+      createAction('vscode-eda.viewNodeConfig', 'Get Node Config', [commandArg]),
+      createAction('vscode-eda.sshTopoNode', 'SSH To Node', [commandArg]),
+      createAction(CMD_EDIT_RESOURCE, LABEL_EDIT_RESOURCE, [commandArg]),
+      createAction(CMD_DELETE_RESOURCE, LABEL_DELETE_RESOURCE, [commandArg])
+    ];
+  }
+
+  if (contextValue === 'crd-instance') {
+    return [
+      ...common,
+      createAction('vscode-eda.showCRDDefinition', 'Show CRD Definition', [commandArg]),
+      createAction(CMD_EDIT_RESOURCE, LABEL_EDIT_RESOURCE, [commandArg]),
+      createAction(CMD_DELETE_RESOURCE, LABEL_DELETE_RESOURCE, [commandArg])
+    ];
+  }
+
+  if (contextValue === 'stream-item') {
+    return [
+      ...common,
+      createAction(CMD_EDIT_RESOURCE, LABEL_EDIT_RESOURCE, [commandArg]),
+      createAction(CMD_DELETE_RESOURCE, LABEL_DELETE_RESOURCE, [commandArg])
+    ];
+  }
+
+  return common;
+}
+
+function isResourceTreeItem(item: TreeItemBase): boolean {
+  if (item.collapsibleState !== vscode.TreeItemCollapsibleState.None) {
+    return false;
+  }
+  if (item.contextValue === CONTEXT_MESSAGE || item.contextValue === CONTEXT_INFO) {
+    return false;
+  }
+  return typeof item.resourceType === 'string' && item.resourceType.length > 0;
+}
+
+async function getProviderChildren(provider: ResourceTreeProvider, element?: TreeItemBase): Promise<TreeItemBase[]> {
+  const result = await Promise.resolve(provider.getChildren(element));
+  if (!Array.isArray(result)) {
+    return [];
+  }
+  return result;
+}
+
+function makeVisitKey(item: TreeItemBase): string {
+  if (typeof item.id === 'string' && item.id.length > 0) {
+    return item.id;
+  }
+  return [
+    item.contextValue || '',
+    labelToText(item.label),
+    item.namespace || '',
+    item.resourceType || ''
+  ].join('|');
+}
+
+async function findNodeById(provider: ResourceTreeProvider, nodeId: string): Promise<TreeItemBase | undefined> {
+  const stack = await getProviderChildren(provider);
+  const visited = new Set<string>();
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) {
+      continue;
+    }
+
+    const currentId = typeof node.id === 'string' ? node.id : '';
+    if (currentId === nodeId) {
+      return node;
+    }
+
+    const visitKey = makeVisitKey(node);
+    if (visited.has(visitKey)) {
+      continue;
+    }
+    visited.add(visitKey);
+
+    const children = await getProviderChildren(provider, node);
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index]);
+    }
+  }
+
+  return undefined;
+}
+
+async function collectStreamItems(provider: ResourceTreeProvider, streamNode: TreeItemBase): Promise<TreeItemBase[]> {
+  const children = await getProviderChildren(provider, streamNode);
+  return children.filter(isResourceTreeItem);
+}
+
+async function collectCategoryItems(provider: ResourceTreeProvider, categoryNode: TreeItemBase): Promise<TreeItemBase[]> {
+  const resources: TreeItemBase[] = [];
+  const streams = await getProviderChildren(provider, categoryNode);
+  for (const streamNode of streams) {
+    if (streamNode.contextValue !== CONTEXT_STREAM) {
+      continue;
+    }
+    resources.push(...(await collectStreamItems(provider, streamNode)));
+  }
+  return resources;
+}
+
+async function collectTrackedStreamItems(
+  provider: ResourceTreeProvider,
+  trackedStreams: ReadonlySet<string>
+): Promise<TreeItemBase[]> {
+  if (trackedStreams.size === 0) {
+    return [];
+  }
+
+  const resources: TreeItemBase[] = [];
+  const stack = await getProviderChildren(provider);
+  const visited = new Set<string>();
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) {
+      continue;
+    }
+
+    const visitKey = makeVisitKey(node);
+    if (visited.has(visitKey)) {
+      continue;
+    }
+    visited.add(visitKey);
+
+    if (node.contextValue === CONTEXT_STREAM && trackedStreams.has(labelToText(node.label))) {
+      resources.push(...(await collectStreamItems(provider, node)));
+      continue;
+    }
+
+    const children = await getProviderChildren(provider, node);
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index]);
+    }
+  }
+
+  return resources;
+}
+
+async function collectCurrentResources(
+  provider: ResourceTreeProvider,
+  payload: ExplorerResourceListPayload
+): Promise<TreeItemBase[]> {
+  if (payload.sourceNodeId && payload.sourceNodeContext) {
+    const selectedNode = await findNodeById(provider, payload.sourceNodeId);
+    if (!selectedNode) {
+      return [];
+    }
+
+    if (payload.sourceNodeContext === CONTEXT_STREAM) {
+      return collectStreamItems(provider, selectedNode);
+    }
+
+    return collectCategoryItems(provider, selectedNode);
+  }
+
+  const trackedStreams = new Set(
+    payload.resources
+      .map(resource => normalizeLookupSegment(resource.stream))
+      .filter(stream => stream.length > 0)
+  );
+  return collectTrackedStreamItems(provider, trackedStreams);
+}
+
+function toResourceListItem(
+  item: TreeItemBase,
+  index: number,
+  existingById: Map<string, ExplorerResourceListItemPayload>
+): ExplorerResourceListItemPayload {
+  const existing = typeof item.id === 'string' ? existingById.get(item.id) : undefined;
+  const commandArg = buildResourceCommandArgument(item);
+  const generatedActions = buildResourceActions(item.contextValue, commandArg);
+  const mergedActions = dedupeActions([
+    ...(existing?.actions || []),
+    ...generatedActions
+  ]);
+  const generatedPrimaryAction = mergedActions.find(action => action.command === CMD_VIEW_RESOURCE)
+    || mergedActions[0];
+
+  const id = typeof item.id === 'string' && item.id.length > 0
+    ? item.id
+    : `live-resource:${index}:${labelToText(item.label)}`;
+  const label = labelToText(item.label);
+  const name = resolveName(item);
+  const namespace = resolveNamespace(item);
+  const kind = item.resource?.kind;
+  const stream = item.resourceType;
+  const apiVersion = item.resource?.apiVersion;
+  const statusDescription = resolveStatusDescription(item);
+
+  return {
+    id,
+    label,
+    name,
+    namespace,
+    kind,
+    stream,
+    labels: formatLabels(item),
+    apiVersion,
+    state: statusDescription,
+    description: descriptionToText(item.description) || statusDescription,
+    statusDescription,
+    statusIndicator: item.status?.indicator,
+    primaryAction: existing?.primaryAction || generatedPrimaryAction || commandToAction(item.command),
+    actions: mergedActions
+  };
+}
+
+function sortResourceItems(resources: ExplorerResourceListItemPayload[]): ExplorerResourceListItemPayload[] {
+  return resources.slice().sort((left, right) => {
+    const leftKey = makeSortKey(left.namespace, left.name);
+    const rightKey = makeSortKey(right.namespace, right.name);
+    if (leftKey !== rightKey) {
+      return leftKey.localeCompare(rightKey);
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+async function buildLivePayload(
+  provider: ResourceTreeProvider,
+  payload: ExplorerResourceListPayload
+): Promise<ExplorerResourceListPayload> {
+  const currentItems = await collectCurrentResources(provider, payload);
+  const existingById = new Map(
+    payload.resources.map(resource => [resource.id, resource] as const)
+  );
+  const resources = sortResourceItems(
+    currentItems.map((item, index) => toResourceListItem(item, index, existingById))
+  );
+
+  return {
+    ...payload,
+    resources
+  };
+}
+
+function createLiveDataSource(
+  payload: ExplorerResourceListPayload,
+  provider?: ResourceTreeProvider
+): {
+  loadPayload: () => Promise<ExplorerResourceListPayload>;
+  onDidChangeData: vscode.Event<unknown>;
+} | undefined {
+  if (!provider?.onDidChangeTreeData) {
+    return undefined;
+  }
+
+  return {
+    loadPayload: () => buildLivePayload(provider, payload),
+    onDidChangeData: provider.onDidChangeTreeData as vscode.Event<unknown>
+  };
+}
+
+export function registerExplorerResourceListCommand(
+  context: vscode.ExtensionContext,
+  provider?: ResourceTreeProvider
+): void {
   const command = vscode.commands.registerCommand('vscode-eda.openExplorerResourceList', async (value: unknown) => {
     const payload = normalizePayload(value);
     if (!payload) {
@@ -124,7 +590,18 @@ export function registerExplorerResourceListCommand(context: vscode.ExtensionCon
     }
 
     const { ExplorerResourceListPanel } = await import('../webviews/explorer/explorerResourceListPanel');
-    ExplorerResourceListPanel.show(context, payload);
+    const dataSource = createLiveDataSource(payload, provider);
+    if (!dataSource) {
+      ExplorerResourceListPanel.show(context, payload);
+      return;
+    }
+
+    try {
+      const initialPayload = await dataSource.loadPayload();
+      ExplorerResourceListPanel.show(context, initialPayload, dataSource);
+    } catch {
+      ExplorerResourceListPanel.show(context, payload, dataSource);
+    }
   });
 
   context.subscriptions.push(command);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -590,7 +590,7 @@ async function initializeTreeViewsAndCommands(
     transactionProvider: edaTransactionProvider
   });
   registerResourceBrowserCommand(context);
-  registerExplorerResourceListCommand(context);
+  registerExplorerResourceListCommand(context, namespaceProvider);
   registerCredentialCommands(context);
   registerApplyYamlFileCommand(context);
 }

--- a/src/webviews/explorer/explorerResourceListTypes.ts
+++ b/src/webviews/explorer/explorerResourceListTypes.ts
@@ -46,6 +46,8 @@ export interface ExplorerResourceListPayload {
   title: string;
   namespace: string;
   viewKind?: ExplorerResourceListViewKind;
+  sourceNodeId?: string;
+  sourceNodeContext?: 'resource-category' | 'stream';
   resources: ExplorerResourceListItemPayload[];
 }
 

--- a/src/webviews/explorer/resourceSectionTree.tsx
+++ b/src/webviews/explorer/resourceSectionTree.tsx
@@ -659,6 +659,8 @@ export const ResourceSectionTree = memo(function ResourceSectionTree({
     const payload: ExplorerResourceListPayload = {
       title,
       namespace: selectedNamespace,
+      sourceNodeId: nodeId,
+      sourceNodeContext: edaLookup.streamById.has(nodeId) ? 'stream' : 'resource-category',
       resources: resources.map((resource) => ({
         id: resource.id,
         label: resource.label,


### PR DESCRIPTION
## Summary
- make Explorer Resource List live-refresh from namespace provider events
- rebuild row set on refresh (not status-only), so newly created resources appear and deleted resources disappear while panel is open
- keep live status updates (`state`, `statusDescription`, `statusIndicator`)
- ensure newly discovered rows have the expected row action buttons (View YAML, edit/delete, and resource-specific actions)
- include source selection metadata in payload (`sourceNodeId`, `sourceNodeContext`) so refresh rebuilds from the same stream/category

## Why
Issue #174 reports table state drifting from actual resource state and generally non-streaming behavior. This change keeps the table synchronized with live provider data, including row add/remove updates.

## Changed Files
- `src/commands/explorerResourceListCommand.ts`
- `src/webviews/explorer/resourceSectionTree.tsx`
- `src/webviews/explorer/explorerResourceListTypes.ts`
- `src/extension.ts`

## Validation
- `npm run check-types`
- `npm run package`

Fixes #174
